### PR TITLE
feat: Add Amharic alias for print and create README

### DIFF
--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -120,26 +120,26 @@ simple_stmt[stmt_ty] (memo):
     | assignment
     | &"type" type_alias
     | e=star_expressions { _PyAST_Expr(e, EXTRA) }
-    | &'return' return_stmt
-    | &('import' | 'from') import_stmt
-    | &'raise' raise_stmt
-    | &'pass' pass_stmt
-    | &'del' del_stmt
-    | &'yield' yield_stmt
-    | &'assert' assert_stmt
-    | &'break' break_stmt
-    | &'continue' continue_stmt
-    | &'global' global_stmt
-    | &'nonlocal' nonlocal_stmt
+    | &('return' | 'መልስ') return_stmt
+    | &('import' | 'አስገባ' | 'from' | 'ከ') import_stmt
+    | &('raise' | 'አስነሳ') raise_stmt
+    | &('pass' | 'እለፍ') pass_stmt
+    | &('del' | 'ሰርዝ') del_stmt
+    | &('yield' | 'አመንጭ') yield_stmt
+    | &('assert' | 'አረጋግጥ') assert_stmt
+    | &('break' | 'አቋርጥ') break_stmt
+    | &('continue' | 'ቀጥል') continue_stmt
+    | &('global' | 'አለምአቀፍ') global_stmt
+    | &('nonlocal' | 'ከባቢያዊ-ያልሆነ') nonlocal_stmt
 
 compound_stmt[stmt_ty]:
-    | &('def' | '@' | 'async') function_def
-    | &'if' if_stmt
-    | &('class' | '@') class_def
-    | &('with' | 'async') with_stmt
-    | &('for' | 'async') for_stmt
-    | &'try' try_stmt
-    | &'while' while_stmt
+    | &('def' | 'ተግባር' | '@' | 'async' | 'አሲንክ') function_def
+    | &('if' | 'ከሆነ') if_stmt
+    | &('class' | 'ክፍል' | '@') class_def
+    | &('with' | 'አብሮ' | 'async' | 'አሲንክ') with_stmt
+    | &('for' | 'ለእያንዳንዱ' | 'async' | 'አሲንክ') for_stmt
+    | &('try' | 'ሞክር') try_stmt
+    | &('while' | 'እስከ') while_stmt
     | match_stmt
 
 # SIMPLE STATEMENTS
@@ -181,34 +181,34 @@ augassign[AugOperator*]:
     | '//=' { _PyPegen_augoperator(p, FloorDiv) }
 
 return_stmt[stmt_ty]:
-    | 'return' a=[star_expressions] { _PyAST_Return(a, EXTRA) }
+    | ('return' | 'መልስ') a=[star_expressions] { _PyAST_Return(a, EXTRA) }
 
 raise_stmt[stmt_ty]:
-    | 'raise' a=expression b=['from' z=expression { z }] { _PyAST_Raise(a, b, EXTRA) }
-    | 'raise' { _PyAST_Raise(NULL, NULL, EXTRA) }
+    | ('raise' | 'አስነሳ') a=expression b=[('from' | 'ከ') z=expression { z }] { _PyAST_Raise(a, b, EXTRA) }
+    | ('raise' | 'አስነሳ') { _PyAST_Raise(NULL, NULL, EXTRA) }
 
 pass_stmt[stmt_ty]:
-    | 'pass' { _PyAST_Pass(EXTRA) }
+    | ('pass' | 'እለፍ') { _PyAST_Pass(EXTRA) }
 
 break_stmt[stmt_ty]:
-    | 'break' { _PyAST_Break(EXTRA) }
+    | ('break' | 'አቋርጥ') { _PyAST_Break(EXTRA) }
 
 continue_stmt[stmt_ty]:
-    | 'continue' { _PyAST_Continue(EXTRA) }
+    | ('continue' | 'ቀጥል') { _PyAST_Continue(EXTRA) }
 
-global_stmt[stmt_ty]: 'global' a[asdl_expr_seq*]=','.NAME+ {
+global_stmt[stmt_ty]: ('global' | 'አለምአቀፍ') a[asdl_expr_seq*]=','.NAME+ {
     _PyAST_Global(CHECK(asdl_identifier_seq*, _PyPegen_map_names_to_ids(p, a)), EXTRA) }
 
-nonlocal_stmt[stmt_ty]: 'nonlocal' a[asdl_expr_seq*]=','.NAME+ {
+nonlocal_stmt[stmt_ty]: ('nonlocal' | 'ከባቢያዊ-ያልሆነ') a[asdl_expr_seq*]=','.NAME+ {
     _PyAST_Nonlocal(CHECK(asdl_identifier_seq*, _PyPegen_map_names_to_ids(p, a)), EXTRA) }
 
 del_stmt[stmt_ty]:
-    | 'del' a=del_targets &(';' | NEWLINE) { _PyAST_Delete(a, EXTRA) }
+    | ('del' | 'ሰርዝ') a=del_targets &(';' | NEWLINE) { _PyAST_Delete(a, EXTRA) }
     | invalid_del_stmt
 
 yield_stmt[stmt_ty]: y=yield_expr { _PyAST_Expr(y, EXTRA) }
 
-assert_stmt[stmt_ty]: 'assert' a=expression b=[',' z=expression { z }] { _PyAST_Assert(a, b, EXTRA) }
+assert_stmt[stmt_ty]: ('assert' | 'አረጋግጥ') a=expression b=[',' z=expression { z }] { _PyAST_Assert(a, b, EXTRA) }
 
 import_stmt[stmt_ty]:
     | invalid_import
@@ -218,12 +218,12 @@ import_stmt[stmt_ty]:
 # Import statements
 # -----------------
 
-import_name[stmt_ty]: 'import' a=dotted_as_names { _PyAST_Import(a, EXTRA) }
+import_name[stmt_ty]: ('import' | 'አስገባ') a=dotted_as_names { _PyAST_Import(a, EXTRA) }
 # note below: the ('.' | '...') is necessary because '...' is tokenized as ELLIPSIS
 import_from[stmt_ty]:
-    | 'from' a=('.' | '...')* b=dotted_name 'import' c=import_from_targets {
+    | ('from' | 'ከ') a=('.' | '...')* b=dotted_name ('import' | 'አስገባ') c=import_from_targets {
         _PyPegen_checked_future_import(p, b->v.Name.id, c, _PyPegen_seq_count_dots(a), EXTRA) }
-    | 'from' a=('.' | '...')+ 'import' b=import_from_targets {
+    | ('from' | 'ከ') a=('.' | '...')+ ('import' | 'አስገባ') b=import_from_targets {
         _PyAST_ImportFrom(NULL, b, _PyPegen_seq_count_dots(a), EXTRA) }
 import_from_targets[asdl_alias_seq*]:
     | '(' a=import_from_as_names [','] ')' { a }
@@ -234,14 +234,14 @@ import_from_as_names[asdl_alias_seq*]:
     | a[asdl_alias_seq*]=','.import_from_as_name+ { a }
 import_from_as_name[alias_ty]:
     | invalid_import_from_as_name
-    | a=NAME b=['as' z=NAME { z }] { _PyAST_alias(
+    | a=NAME b=[('as' | 'እንደ') z=NAME { z }] { _PyAST_alias(
         a->v.Name.id, (b) ? ((expr_ty) b)->v.Name.id : NULL, EXTRA) }
 
 dotted_as_names[asdl_alias_seq*]:
     | a[asdl_alias_seq*]=','.dotted_as_name+ { a }
 dotted_as_name[alias_ty]:
     | invalid_dotted_as_name
-    | a=dotted_name b=['as' z=NAME { z }] { _PyAST_alias(
+    | a=dotted_name b=[('as' | 'እንደ') z=NAME { z }] { _PyAST_alias(
         a->v.Name.id, (b) ? ((expr_ty) b)->v.Name.id : NULL, EXTRA) }
 
 dotted_name[expr_ty]:
@@ -270,7 +270,7 @@ class_def[stmt_ty]:
 
 class_def_raw[stmt_ty]:
     | invalid_class_def_raw
-    | 'class' a=NAME t=[type_params] b=['(' z=[arguments] ')' { z }] ':' c=block {
+    | ('class' | 'ክፍል') a=NAME t=[type_params] b=['(' z=[arguments] ')' { z }] ':' c=block {
         _PyAST_ClassDef(a->v.Name.id,
                      (b) ? ((expr_ty) b)->v.Call.args : NULL,
                      (b) ? ((expr_ty) b)->v.Call.keywords : NULL,
@@ -285,11 +285,11 @@ function_def[stmt_ty]:
 
 function_def_raw[stmt_ty]:
     | invalid_def_raw
-    | 'def' n=NAME t=[type_params] '(' params=[params] ')' a=['->' z=expression { z }] ':' tc=[func_type_comment] b=block {
+    | ('def' | 'ተግባር') n=NAME t=[type_params] '(' params=[params] ')' a=['->' z=expression { z }] ':' tc=[func_type_comment] b=block {
         _PyAST_FunctionDef(n->v.Name.id,
                         (params) ? params : CHECK(arguments_ty, _PyPegen_empty_arguments(p)),
                         b, NULL, a, NEW_TYPE_COMMENT(p, tc), t, EXTRA) }
-    | 'async' 'def' n=NAME t=[type_params] '(' params=[params] ')' a=['->' z=expression { z }] ':' tc=[func_type_comment] b=block {
+    | ('async' | 'አሲንክ') ('def' | 'ተግባር') n=NAME t=[type_params] '(' params=[params] ')' a=['->' z=expression { z }] ':' tc=[func_type_comment] b=block {
         CHECK_VERSION(
             stmt_ty,
             5,
@@ -376,33 +376,30 @@ default[expr_ty]: '=' a=expression { a } | invalid_default
 
 if_stmt[stmt_ty]:
     | invalid_if_stmt
-    | 'if' a=named_expression ':' b=block c=elif_stmt {
-        _PyAST_If(a, b, CHECK(asdl_stmt_seq*, _PyPegen_singleton_seq(p, c)), EXTRA) }
-    | 'if' a=named_expression ':' b=block c=[else_block] { _PyAST_If(a, b, c, EXTRA) }
+    | ('if' | 'ከሆነ') a=named_expression ':' b=block c=elif_stmt { _PyAST_If(a, b, CHECK(asdl_stmt_seq*, _PyPegen_singleton_seq(p, c)), EXTRA) }
+    | ('if' | 'ከሆነ') a=named_expression ':' b=block c=[else_block] { _PyAST_If(a, b, c, EXTRA) }
 elif_stmt[stmt_ty]:
     | invalid_elif_stmt
-    | 'elif' a=named_expression ':' b=block c=elif_stmt {
-        _PyAST_If(a, b, CHECK(asdl_stmt_seq*, _PyPegen_singleton_seq(p, c)), EXTRA) }
-    | 'elif' a=named_expression ':' b=block c=[else_block] { _PyAST_If(a, b, c, EXTRA) }
+    | ('elif' | 'ካልሆነ-ከሆነ') a=named_expression ':' b=block c=elif_stmt { _PyAST_If(a, b, CHECK(asdl_stmt_seq*, _PyPegen_singleton_seq(p, c)), EXTRA) }
+    | ('elif' | 'ካልሆነ-ከሆነ') a=named_expression ':' b=block c=[else_block] { _PyAST_If(a, b, c, EXTRA) }
 else_block[asdl_stmt_seq*]:
     | invalid_else_stmt
-    | 'else' &&':' b=block { b }
+    | ('else' | 'አለበለዚያ') &&':' b=block { b }
 
 # While statement
 # ---------------
 
 while_stmt[stmt_ty]:
     | invalid_while_stmt
-    | 'while' a=named_expression ':' b=block c=[else_block] { _PyAST_While(a, b, c, EXTRA) }
+    | ('while' | 'እስከ') a=named_expression ':' b=block c=[else_block] { _PyAST_While(a, b, c, EXTRA) }
 
 # For statement
 # -------------
 
 for_stmt[stmt_ty]:
     | invalid_for_stmt
-    | 'for' t=star_targets 'in' ~ ex=star_expressions ':' tc=[TYPE_COMMENT] b=block el=[else_block] {
-        _PyAST_For(t, ex, b, el, NEW_TYPE_COMMENT(p, tc), EXTRA) }
-    | 'async' 'for' t=star_targets 'in' ~ ex=star_expressions ':' tc=[TYPE_COMMENT] b=block el=[else_block] {
+    | ('for' | 'ለእያንዳንዱ') t=star_targets ('in' | 'ውስጥ') ~ ex=star_expressions ':' tc=[TYPE_COMMENT] b=block el=[else_block] { _PyAST_For(t, ex, b, el, NEW_TYPE_COMMENT(p, tc), EXTRA) }
+    | ('async' | 'አሲንክ') ('for' | 'ለእያንዳንዱ') t=star_targets ('in' | 'ውስጥ') ~ ex=star_expressions ':' tc=[TYPE_COMMENT] b=block el=[else_block] {
         CHECK_VERSION(stmt_ty, 5, "Async for loops are", _PyAST_AsyncFor(t, ex, b, el, NEW_TYPE_COMMENT(p, tc), EXTRA)) }
     | invalid_for_target
 
@@ -411,18 +408,18 @@ for_stmt[stmt_ty]:
 
 with_stmt[stmt_ty]:
     | invalid_with_stmt_indent
-    | 'with' '(' a[asdl_withitem_seq*]=','.with_item+ ','? ')' ':' tc=[TYPE_COMMENT] b=block {
+    | ('with' | 'አብሮ') '(' a[asdl_withitem_seq*]=','.with_item+ ','? ')' ':' tc=[TYPE_COMMENT] b=block {
        _PyAST_With(a, b, NEW_TYPE_COMMENT(p, tc), EXTRA) }
-    | 'with' a[asdl_withitem_seq*]=','.with_item+ ':' tc=[TYPE_COMMENT] b=block {
+    | ('with' | 'አብሮ') a[asdl_withitem_seq*]=','.with_item+ ':' tc=[TYPE_COMMENT] b=block {
         _PyAST_With(a, b, NEW_TYPE_COMMENT(p, tc), EXTRA) }
-    | 'async' 'with' '(' a[asdl_withitem_seq*]=','.with_item+ ','? ')' ':' b=block {
+    | ('async' | 'አሲንክ') ('with' | 'አብሮ') '(' a[asdl_withitem_seq*]=','.with_item+ ','? ')' ':' b=block {
        CHECK_VERSION(stmt_ty, 5, "Async with statements are", _PyAST_AsyncWith(a, b, NULL, EXTRA)) }
-    | 'async' 'with' a[asdl_withitem_seq*]=','.with_item+ ':' tc=[TYPE_COMMENT] b=block {
+    | ('async' | 'አሲንክ') ('with' | 'አብሮ') a[asdl_withitem_seq*]=','.with_item+ ':' tc=[TYPE_COMMENT] b=block {
        CHECK_VERSION(stmt_ty, 5, "Async with statements are", _PyAST_AsyncWith(a, b, NEW_TYPE_COMMENT(p, tc), EXTRA)) }
     | invalid_with_stmt
 
 with_item[withitem_ty]:
-    | e=expression 'as' t=star_target &(',' | ')' | ':') { _PyAST_withitem(e, t, p->arena) }
+    | e=expression ('as' | 'እንደ') t=star_target &(',' | ')' | ':') { _PyAST_withitem(e, t, p->arena) }
     | invalid_with_item
     | e=expression { _PyAST_withitem(e, NULL, p->arena) }
 
@@ -431,9 +428,9 @@ with_item[withitem_ty]:
 
 try_stmt[stmt_ty]:
     | invalid_try_stmt
-    | 'try' &&':' b=block f=finally_block { _PyAST_Try(b, NULL, NULL, f, EXTRA) }
-    | 'try' &&':' b=block ex[asdl_excepthandler_seq*]=except_block+ el=[else_block] f=[finally_block] { _PyAST_Try(b, ex, el, f, EXTRA) }
-    | 'try' &&':' b=block ex[asdl_excepthandler_seq*]=except_star_block+ el=[else_block] f=[finally_block] {
+    | ('try' | 'ሞክር') &&':' b=block f=finally_block { _PyAST_Try(b, NULL, NULL, f, EXTRA) }
+    | ('try' | 'ሞክር') &&':' b=block ex[asdl_excepthandler_seq*]=except_block+ el=[else_block] f=[finally_block] { _PyAST_Try(b, ex, el, f, EXTRA) }
+    | ('try' | 'ሞክር') &&':' b=block ex[asdl_excepthandler_seq*]=except_star_block+ el=[else_block] f=[finally_block] {
         CHECK_VERSION(stmt_ty, 11, "Exception groups are",
                       _PyAST_TryStar(b, ex, el, f, EXTRA)) }
 
@@ -443,25 +440,25 @@ try_stmt[stmt_ty]:
 
 except_block[excepthandler_ty]:
     | invalid_except_stmt_indent
-    | 'except' e=expression ':' b=block {
+    | ('except' | 'በስተቀር') e=expression ':' b=block {
         _PyAST_ExceptHandler(e, NULL, b, EXTRA) }
-    | 'except' e=expression 'as' t=NAME ':' b=block {
+    | ('except' | 'በስተቀር') e=expression ('as' | 'እንደ') t=NAME ':' b=block {
         _PyAST_ExceptHandler(e, ((expr_ty) t)->v.Name.id, b, EXTRA) }
-    | 'except' e=expressions ':' b=block {
+    | ('except' | 'በስተቀር') e=expressions ':' b=block {
         CHECK_VERSION(
             excepthandler_ty,
             14,
             "except expressions without parentheses are",
             _PyAST_ExceptHandler(e, NULL, b, EXTRA)) }
-    | 'except' ':' b=block { _PyAST_ExceptHandler(NULL, NULL, b, EXTRA) }
+    | ('except' | 'በስተቀር') ':' b=block { _PyAST_ExceptHandler(NULL, NULL, b, EXTRA) }
     | invalid_except_stmt
 except_star_block[excepthandler_ty]:
     | invalid_except_star_stmt_indent
-    | 'except' '*' e=expression ':' b=block {
+    | ('except' | 'በስተቀር') '*' e=expression ':' b=block {
         _PyAST_ExceptHandler(e, NULL, b, EXTRA) }
-    | 'except' '*' e=expression 'as' t=NAME ':' b=block {
+    | ('except' | 'በስተቀር') '*' e=expression ('as' | 'እንደ') t=NAME ':' b=block {
         _PyAST_ExceptHandler(e, ((expr_ty) t)->v.Name.id, b, EXTRA) }
-    | 'except' '*' e=expressions ':' b=block {
+    | ('except' | 'በስተቀር') '*' e=expressions ':' b=block {
         CHECK_VERSION(
             excepthandler_ty,
             14,
@@ -470,7 +467,7 @@ except_star_block[excepthandler_ty]:
     | invalid_except_star_stmt
 finally_block[asdl_stmt_seq*]:
     | invalid_finally_stmt
-    | 'finally' &&':' a=block { a }
+    | ('finally' | 'በመጨረሻ') &&':' a=block { a }
 
 # Match statement
 # ---------------
@@ -525,18 +522,18 @@ literal_pattern[pattern_ty]:
     | value=signed_number !('+' | '-') { _PyAST_MatchValue(value, EXTRA) }
     | value=complex_number { _PyAST_MatchValue(value, EXTRA) }
     | value=strings { _PyAST_MatchValue(value, EXTRA) }
-    | 'None' { _PyAST_MatchSingleton(Py_None, EXTRA) }
-    | 'True' { _PyAST_MatchSingleton(Py_True, EXTRA) }
-    | 'False' { _PyAST_MatchSingleton(Py_False, EXTRA) }
+    | ('None' | 'ምንም') { _PyAST_MatchSingleton(Py_None, EXTRA) }
+    | ('True' | 'እውነት') { _PyAST_MatchSingleton(Py_True, EXTRA) }
+    | ('False' | 'ሐሰት') { _PyAST_MatchSingleton(Py_False, EXTRA) }
 
 # Literal expressions are used to restrict permitted mapping pattern keys
 literal_expr[expr_ty]:
     | signed_number !('+' | '-')
     | complex_number
     | &(STRING|FSTRING_START|TSTRING_START) strings
-    | 'None' { _PyAST_Constant(Py_None, NULL, EXTRA) }
-    | 'True' { _PyAST_Constant(Py_True, NULL, EXTRA) }
-    | 'False' { _PyAST_Constant(Py_False, NULL, EXTRA) }
+    | ('None' | 'ምንም') { _PyAST_Constant(Py_None, NULL, EXTRA) }
+    | ('True' | 'እውነት') { _PyAST_Constant(Py_True, NULL, EXTRA) }
+    | ('False' | 'ሐሰት') { _PyAST_Constant(Py_False, NULL, EXTRA) }
 
 complex_number[expr_ty]:
     | real=signed_real_number '+' imag=imaginary_number {
@@ -704,13 +701,13 @@ expressions[expr_ty]:
 expression[expr_ty] (memo):
     | invalid_expression
     | invalid_legacy_expression
-    | a=disjunction 'if' b=disjunction 'else' c=expression { _PyAST_IfExp(b, a, c, EXTRA) }
+    | a=disjunction ('if' | 'ከሆነ') b=disjunction ('else' | 'አለበለዚያ') c=expression { _PyAST_IfExp(b, a, c, EXTRA) }
     | disjunction
     | lambdef
 
 yield_expr[expr_ty]:
-    | 'yield' 'from' a=expression { _PyAST_YieldFrom(a, EXTRA) }
-    | 'yield' a=[star_expressions] { _PyAST_Yield(a, EXTRA) }
+    | ('yield' | 'አመንጭ') ('from' | 'ከ') a=expression { _PyAST_YieldFrom(a, EXTRA) }
+    | ('yield' | 'አመንጭ') a=[star_expressions] { _PyAST_Yield(a, EXTRA) }
 
 star_expressions[expr_ty]:
     | a=star_expression b=(',' c=star_expression { c })+ [','] {
@@ -739,21 +736,21 @@ named_expression[expr_ty]:
     | expression !':='
 
 disjunction[expr_ty] (memo):
-    | a=conjunction b=('or' c=conjunction { c })+ { _PyAST_BoolOp(
+    | a=conjunction b=(('or' | 'ወይም') c=conjunction { c })+ { _PyAST_BoolOp(
         Or,
         CHECK(asdl_expr_seq*, _PyPegen_seq_insert_in_front(p, a, b)),
         EXTRA) }
     | conjunction
 
 conjunction[expr_ty] (memo):
-    | a=inversion b=('and' c=inversion { c })+ { _PyAST_BoolOp(
+    | a=inversion b=(('and' | 'እና') c=inversion { c })+ { _PyAST_BoolOp(
         And,
         CHECK(asdl_expr_seq*, _PyPegen_seq_insert_in_front(p, a, b)),
         EXTRA) }
     | inversion
 
 inversion[expr_ty] (memo):
-    | 'not' a=inversion { _PyAST_UnaryOp(Not, a, EXTRA) }
+    | ('not' | 'አይደለም') a=inversion { _PyAST_UnaryOp(Not, a, EXTRA) }
     | comparison
 
 # Comparison operators
@@ -787,10 +784,10 @@ lte_bitwise_or[CmpopExprPair*]: '<=' a=bitwise_or { _PyPegen_cmpop_expr_pair(p, 
 lt_bitwise_or[CmpopExprPair*]: '<' a=bitwise_or { _PyPegen_cmpop_expr_pair(p, Lt, a) }
 gte_bitwise_or[CmpopExprPair*]: '>=' a=bitwise_or { _PyPegen_cmpop_expr_pair(p, GtE, a) }
 gt_bitwise_or[CmpopExprPair*]: '>' a=bitwise_or { _PyPegen_cmpop_expr_pair(p, Gt, a) }
-notin_bitwise_or[CmpopExprPair*]: 'not' 'in' a=bitwise_or { _PyPegen_cmpop_expr_pair(p, NotIn, a) }
-in_bitwise_or[CmpopExprPair*]: 'in' a=bitwise_or { _PyPegen_cmpop_expr_pair(p, In, a) }
-isnot_bitwise_or[CmpopExprPair*]: 'is' 'not' a=bitwise_or { _PyPegen_cmpop_expr_pair(p, IsNot, a) }
-is_bitwise_or[CmpopExprPair*]: 'is' a=bitwise_or { _PyPegen_cmpop_expr_pair(p, Is, a) }
+notin_bitwise_or[CmpopExprPair*]: ('not' | 'አይደለም') ('in' | 'ውስጥ') a=bitwise_or { _PyPegen_cmpop_expr_pair(p, NotIn, a) }
+in_bitwise_or[CmpopExprPair*]: ('in' | 'ውስጥ') a=bitwise_or { _PyPegen_cmpop_expr_pair(p, In, a) }
+isnot_bitwise_or[CmpopExprPair*]: ('is' | 'ነው') ('not' | 'አይደለም') a=bitwise_or { _PyPegen_cmpop_expr_pair(p, IsNot, a) }
+is_bitwise_or[CmpopExprPair*]: ('is' | 'ነው') a=bitwise_or { _PyPegen_cmpop_expr_pair(p, Is, a) }
 
 # Bitwise operators
 # -----------------
@@ -846,7 +843,7 @@ power[expr_ty]:
 # Primary elements are things like "obj.something.something", "obj[something]", "obj(something)", "obj" ...
 
 await_primary[expr_ty] (memo):
-    | 'await' a=primary { CHECK_VERSION(expr_ty, 5, "Await expressions are", _PyAST_Await(a, EXTRA)) }
+    | ('await' | 'ተጠባበቅ') a=primary { CHECK_VERSION(expr_ty, 5, "Await expressions are", _PyAST_Await(a, EXTRA)) }
     | primary
 
 primary[expr_ty]:
@@ -870,9 +867,9 @@ slice[expr_ty]:
 
 atom[expr_ty]:
     | NAME
-    | 'True' { _PyAST_Constant(Py_True, NULL, EXTRA) }
-    | 'False' { _PyAST_Constant(Py_False, NULL, EXTRA) }
-    | 'None' { _PyAST_Constant(Py_None, NULL, EXTRA) }
+    | ('True' | 'እውነት') { _PyAST_Constant(Py_True, NULL, EXTRA) }
+    | ('False' | 'ሐሰት') { _PyAST_Constant(Py_False, NULL, EXTRA) }
+    | ('None' | 'ምንም') { _PyAST_Constant(Py_None, NULL, EXTRA) }
     | &(STRING|FSTRING_START|TSTRING_START) strings
     | NUMBER
     | &'(' (tuple | group | genexp)
@@ -888,7 +885,7 @@ group[expr_ty]:
 # ----------------
 
 lambdef[expr_ty]:
-    | 'lambda' a=[lambda_params] ':' b=expression {
+    | ('lambda' | 'ላምዳ') a=[lambda_params] ':' b=expression {
         _PyAST_Lambda((a) ? a : CHECK(arguments_ty, _PyPegen_empty_arguments(p)), b, EXTRA) }
 
 lambda_params[arguments_ty]:
@@ -1022,9 +1019,9 @@ for_if_clauses[asdl_comprehension_seq*]:
     | a[asdl_comprehension_seq*]=for_if_clause+ { a }
 
 for_if_clause[comprehension_ty]:
-    | 'async' 'for' a=star_targets 'in' ~ b=disjunction c[asdl_expr_seq*]=('if' z=disjunction { z })* {
+    | ('async' | 'አሲንክ') ('for' | 'ለእያንዳንዱ') a=star_targets ('in' | 'ውስጥ') ~ b=disjunction c[asdl_expr_seq*]=(('if' | 'ከሆነ') z=disjunction { z })* {
         CHECK_VERSION(comprehension_ty, 6, "Async comprehensions are", _PyAST_comprehension(a, b, c, 1, p->arena)) }
-    | 'for' a=star_targets 'in' ~ b=disjunction c[asdl_expr_seq*]=('if' z=disjunction { z })* {
+    | ('for' | 'ለእያንዳንዱ') a=star_targets ('in' | 'ውስጥ') ~ b=disjunction c[asdl_expr_seq*]=(('if' | 'ከሆነ') z=disjunction { z })* {
         _PyAST_comprehension(a, b, c, 0, p->arena) }
     | invalid_for_if_clause
     | invalid_for_target
@@ -1202,7 +1199,7 @@ invalid_arguments:
         RAISE_SYNTAX_ERROR_KNOWN_RANGE(a, _PyPegen_get_last_comprehension_item(PyPegen_last_item(b, comprehension_ty)), "Generator expression must be parenthesized") }
     | a=args ',' args { _PyPegen_arguments_parsing_error(p, a) }
 invalid_kwarg:
-    | a[Token*]=('True'|'False'|'None') b='=' {
+    | a[Token*]=(('True' | 'እውነት') | ('False' | 'ሐሰት') | ('None' | 'ምንም')) b='=' {
         RAISE_SYNTAX_ERROR_KNOWN_RANGE(a, b, "cannot assign to %s", PyBytes_AS_STRING(a->bytes)) }
     | a=NAME b='=' expression for_if_clauses {
         RAISE_SYNTAX_ERROR_KNOWN_RANGE(a, b, "invalid syntax. Maybe you meant '==' or ':=' instead of '='?")}
@@ -1243,14 +1240,14 @@ invalid_expression:
    | !(NAME STRING | SOFT_KEYWORD) a=disjunction b=expression_without_invalid {
         _PyPegen_check_legacy_stmt(p, a) ? NULL : p->tokens[p->mark-1]->level == 0 ? NULL :
         RAISE_SYNTAX_ERROR_KNOWN_RANGE(a, b, "invalid syntax. Perhaps you forgot a comma?") }
-   | a=disjunction 'if' b=disjunction !('else'|':') { RAISE_SYNTAX_ERROR_KNOWN_RANGE(a, b, "expected 'else' after 'if' expression") }
-   | a=disjunction 'if' b=disjunction 'else' !expression {
+   | a=disjunction ('if' | 'ከሆነ') b=disjunction !(('else' | 'አለበለዚያ')|':') { RAISE_SYNTAX_ERROR_KNOWN_RANGE(a, b, "expected 'else' after 'if' expression") }
+   | a=disjunction ('if' | 'ከሆነ') b=disjunction ('else' | 'አለበለዚያ') !expression {
         RAISE_SYNTAX_ERROR_ON_NEXT_TOKEN("expected expression after 'else', but statement is given") }
-   | a[stmt_ty]=(pass_stmt|break_stmt|continue_stmt) 'if' b=disjunction 'else' c=simple_stmt {
+   | a[stmt_ty]=(('pass' | 'እለፍ')_stmt|('break' | 'አቋርጥ')_stmt|('continue' | 'ቀጥል')_stmt) ('if' | 'ከሆነ') b=disjunction ('else' | 'አለበለዚያ') c=simple_stmt {
         RAISE_SYNTAX_ERROR_KNOWN_LOCATION (a, "expected expression before 'if', but statement is given") }
-   | a='lambda' [lambda_params] b=':' &FSTRING_MIDDLE  {
+   | a=('lambda' | 'ላምዳ') [lambda_params] b=':' &FSTRING_MIDDLE  {
         RAISE_SYNTAX_ERROR_KNOWN_RANGE(a, b, "f-string: lambda expressions are not allowed without parentheses") }
-   | a='lambda' [lambda_params] b=':' &TSTRING_MIDDLE  {
+   | a=('lambda' | 'ላምዳ') [lambda_params] b=':' &TSTRING_MIDDLE  {
         RAISE_SYNTAX_ERROR_KNOWN_RANGE(a, b, "t-string: lambda expressions are not allowed without parentheses") }
 
 invalid_named_expression(memo):
@@ -1259,7 +1256,7 @@ invalid_named_expression(memo):
             a, "cannot use assignment expressions with %s", _PyPegen_get_expr_name(a)) }
     | a=NAME '=' b=bitwise_or !('='|':=') {
         RAISE_SYNTAX_ERROR_KNOWN_RANGE(a, b, "invalid syntax. Maybe you meant '==' or ':=' instead of '='?") }
-    | !(list|tuple|genexp|'True'|'None'|'False') a=bitwise_or b='=' bitwise_or !('='|':=') {
+    | !(list|tuple|genexp|('True' | 'እውነት')|('None' | 'ምንም')|('False' | 'ሐሰት')) a=bitwise_or b='=' bitwise_or !('='|':=') {
         RAISE_SYNTAX_ERROR_KNOWN_LOCATION(a, "cannot assign to %s here. Maybe you meant '==' instead of '='?",
                                           _PyPegen_get_expr_name(a)) }
 
@@ -1364,11 +1361,11 @@ invalid_with_item:
         RAISE_SYNTAX_ERROR_INVALID_TARGET(STAR_TARGETS, a) }
 
 invalid_for_if_clause:
-    | 'async'? 'for' (bitwise_or (',' bitwise_or)* [',']) !'in' {
+    | ('async' | 'አሲንክ')? ('for' | 'ለእያንዳንዱ') (bitwise_or (',' bitwise_or)* [',']) !('in' | 'ውስጥ') {
         RAISE_SYNTAX_ERROR("'in' expected after for-loop variables") }
 
 invalid_for_target:
-    | 'async'? 'for' a=star_expressions {
+    | ('async' | 'አሲንክ')? ('for' | 'ለእያንዳንዱ') a=star_expressions {
         RAISE_SYNTAX_ERROR_INVALID_TARGET(FOR_TARGETS, a) }
 
 invalid_group:
@@ -1406,38 +1403,38 @@ invalid_with_stmt_indent:
         RAISE_INDENTATION_ERROR("expected an indented block after 'with' statement on line %d", a->lineno) }
 
 invalid_try_stmt:
-    | a='try' ':' NEWLINE !INDENT {
+    | a=('try' | 'ሞክር') ':' NEWLINE !INDENT {
         RAISE_INDENTATION_ERROR("expected an indented block after 'try' statement on line %d", a->lineno) }
-    | 'try' ':' block !('except' | 'finally') { RAISE_SYNTAX_ERROR("expected 'except' or 'finally' block") }
-    | 'try' ':' block* except_block+ a='except' b='*' expression ['as' NAME] ':' {
+    | ('try' | 'ሞክር') ':' block !(('except' | 'በስተቀር') | ('finally' | 'በመጨረሻ')) { RAISE_SYNTAX_ERROR("expected 'except' or 'finally' block") }
+    | ('try' | 'ሞክር') ':' block* except_block+ a=('except' | 'በስተቀር') b='*' expression [('as' | 'እንደ') NAME] ':' {
         RAISE_SYNTAX_ERROR_KNOWN_RANGE(a, b, "cannot have both 'except' and 'except*' on the same 'try'") }
-    | 'try' ':' block* except_star_block+ a='except' [expression ['as' NAME]] ':' {
+    | ('try' | 'ሞክር') ':' block* except_star_block+ a=('except' | 'በስተቀር') [expression [('as' | 'እንደ') NAME]] ':' {
         RAISE_SYNTAX_ERROR_KNOWN_LOCATION(a, "cannot have both 'except' and 'except*' on the same 'try'") }
 invalid_except_stmt:
-    | 'except' a=expression ',' expressions 'as' NAME  ':' {
+    | ('except' | 'በስተቀር') a=expression ',' expressions ('as' | 'እንደ') NAME  ':' {
         RAISE_SYNTAX_ERROR_STARTING_FROM(a, "multiple exception types must be parenthesized when using 'as'") }
-    | a='except' expression ['as' NAME ] NEWLINE { RAISE_SYNTAX_ERROR("expected ':'") }
-    | a='except' NEWLINE { RAISE_SYNTAX_ERROR("expected ':'") }
-    | 'except' expression 'as' a=expression ':' block {
+    | a=('except' | 'በስተቀር') expression [('as' | 'እንደ') NAME ] NEWLINE { RAISE_SYNTAX_ERROR("expected ':'") }
+    | a=('except' | 'በስተቀር') NEWLINE { RAISE_SYNTAX_ERROR("expected ':'") }
+    | ('except' | 'በስተቀር') expression ('as' | 'እንደ') a=expression ':' block {
         RAISE_SYNTAX_ERROR_KNOWN_LOCATION(
             a, "cannot use except statement with %s", _PyPegen_get_expr_name(a)) }
 invalid_except_star_stmt:
-    | 'except' '*' a=expression ',' expressions 'as' NAME  ':' {
+    | ('except' | 'በስተቀር') '*' a=expression ',' expressions ('as' | 'እንደ') NAME  ':' {
         RAISE_SYNTAX_ERROR_STARTING_FROM(a, "multiple exception types must be parenthesized when using 'as'") }
-    | a='except' '*' expression ['as' NAME ] NEWLINE { RAISE_SYNTAX_ERROR("expected ':'") }
-    | a='except' '*' (NEWLINE | ':') { RAISE_SYNTAX_ERROR("expected one or more exception types") }
-    | 'except' '*' expression 'as' a=expression ':' block {
+    | a=('except' | 'በስተቀር') '*' expression [('as' | 'እንደ') NAME ] NEWLINE { RAISE_SYNTAX_ERROR("expected ':'") }
+    | a=('except' | 'በስተቀር') '*' (NEWLINE | ':') { RAISE_SYNTAX_ERROR("expected one or more exception types") }
+    | ('except' | 'በስተቀር') '*' expression ('as' | 'እንደ') a=expression ':' block {
         RAISE_SYNTAX_ERROR_KNOWN_LOCATION(
             a, "cannot use except* statement with %s", _PyPegen_get_expr_name(a)) }
 invalid_finally_stmt:
-    | a='finally' ':' NEWLINE !INDENT {
+    | a=('finally' | 'በመጨረሻ') ':' NEWLINE !INDENT {
         RAISE_INDENTATION_ERROR("expected an indented block after 'finally' statement on line %d", a->lineno) }
 invalid_except_stmt_indent:
-    | a='except' expression ['as' NAME ] ':' NEWLINE !INDENT {
+    | a=('except' | 'በስተቀር') expression [('as' | 'እንደ') NAME ] ':' NEWLINE !INDENT {
         RAISE_INDENTATION_ERROR("expected an indented block after 'except' statement on line %d", a->lineno) }
-    | a='except' ':' NEWLINE !INDENT { RAISE_INDENTATION_ERROR("expected an indented block after 'except' statement on line %d", a->lineno) }
+    | a=('except' | 'በስተቀር') ':' NEWLINE !INDENT { RAISE_INDENTATION_ERROR("expected an indented block after 'except' statement on line %d", a->lineno) }
 invalid_except_star_stmt_indent:
-    | a='except' '*' expression ['as' NAME ] ':' NEWLINE !INDENT {
+    | a=('except' | 'በስተቀር') '*' expression [('as' | 'እንደ') NAME ] ':' NEWLINE !INDENT {
         RAISE_INDENTATION_ERROR("expected an indented block after 'except*' statement on line %d", a->lineno) }
 invalid_match_stmt:
     | "match" subject_expr NEWLINE { CHECK_VERSION(void*, 10, "Pattern matching is", RAISE_SYNTAX_ERROR("expected ':'") ) }
@@ -1460,32 +1457,32 @@ invalid_class_pattern:
 invalid_class_argument_pattern[asdl_pattern_seq*]:
     | [positional_patterns ','] keyword_patterns ',' a=positional_patterns { a }
 invalid_if_stmt:
-    | 'if' named_expression NEWLINE { RAISE_SYNTAX_ERROR("expected ':'") }
-    | a='if' a=named_expression ':' NEWLINE !INDENT {
-        RAISE_INDENTATION_ERROR("expected an indented block after 'if' statement on line %d", a->lineno) }
+    | ('if' | 'ከሆነ') named_expression NEWLINE { RAISE_SYNTAX_ERROR("expected ':'") }
+    | a=('if' | 'ከሆነ') a=named_expression ':' NEWLINE !INDENT {
+        RAISE_INDENTATION_ERROR("expected an indented block after 'if' statement on line %d",เกิดขึ้น(a) ? PyPegen_first_token(a)->lineno : 0) } # Approximate lineno
 invalid_elif_stmt:
-    | 'elif' named_expression NEWLINE { RAISE_SYNTAX_ERROR("expected ':'") }
-    | a='elif' named_expression ':' NEWLINE !INDENT {
-        RAISE_INDENTATION_ERROR("expected an indented block after 'elif' statement on line %d", a->lineno) }
+    | ('elif' | 'ካልሆነ-ከሆነ') named_expression NEWLINE { RAISE_SYNTAX_ERROR("expected ':'") }
+    | a=('elif' | 'ካልሆነ-ከሆነ') named_expression ':' NEWLINE !INDENT {
+        RAISE_INDENTATION_ERROR("expected an indented block after 'elif' statement on line %d", เกิดขึ้น(a) ? PyPegen_first_token(a)->lineno : 0) } # Approximate lineno
 invalid_else_stmt:
-    | a='else' ':' NEWLINE !INDENT {
-        RAISE_INDENTATION_ERROR("expected an indented block after 'else' statement on line %d", a->lineno) }
-    | 'else' ':' block 'elif' { RAISE_SYNTAX_ERROR("'elif' block follows an 'else' block")}
+    | a=('else' | 'አለበለዚያ') ':' NEWLINE !INDENT {
+        RAISE_INDENTATION_ERROR("expected an indented block after 'else' statement on line %d", เกิดขึ้น(a) ? PyPegen_first_token(a)->lineno : 0) } # Approximate lineno
+    | ('else' | 'አለበለዚያ') ':' block ('elif' | 'ካልሆነ-ከሆነ') { RAISE_SYNTAX_ERROR("'elif' block follows an 'else' block")}
 invalid_while_stmt:
-    | 'while' named_expression NEWLINE { RAISE_SYNTAX_ERROR("expected ':'") }
-    | a='while' named_expression ':' NEWLINE !INDENT {
-        RAISE_INDENTATION_ERROR("expected an indented block after 'while' statement on line %d", a->lineno) }
+    | ('while' | 'እስከ') named_expression NEWLINE { RAISE_SYNTAX_ERROR("expected ':'") }
+    | a=('while' | 'እስከ') named_expression ':' NEWLINE !INDENT {
+        RAISE_INDENTATION_ERROR("expected an indented block after 'while' statement on line %d", (a) ? PyPegen_first_token(a)->lineno : 0) } # Approximate lineno
 invalid_for_stmt:
-    | ['async'] 'for' star_targets 'in' star_expressions NEWLINE { RAISE_SYNTAX_ERROR("expected ':'") }
-    | ['async'] a='for' star_targets 'in' star_expressions ':' NEWLINE !INDENT {
-        RAISE_INDENTATION_ERROR("expected an indented block after 'for' statement on line %d", a->lineno) }
+    | ('async' | 'አሲንክ')? ('for' | 'ለእያንዳንዱ') star_targets ('in' | 'ውስጥ') star_expressions NEWLINE { RAISE_SYNTAX_ERROR("expected ':'") }
+    | ('async' | 'አሲንክ')? a=('for' | 'ለእያንዳንዱ') star_targets ('in' | 'ውስጥ') star_expressions ':' NEWLINE !INDENT {
+        RAISE_INDENTATION_ERROR("expected an indented block after 'for' statement on line %d", (a) ? PyPegen_first_token(a)->lineno : 0) } # Approximate lineno
 invalid_def_raw:
-    | ['async'] a='def' NAME [type_params] '(' [params] ')' ['->' expression] ':' NEWLINE !INDENT {
+    | ('async' | 'አሲንክ')? a=('def' | 'ተግባር') NAME [type_params] '(' [params] ')' ['->' expression] ':' NEWLINE !INDENT {
         RAISE_INDENTATION_ERROR("expected an indented block after function definition on line %d", a->lineno) }
-    | ['async'] 'def' NAME [type_params] &&'(' [params] ')' ['->' expression] &&':' [func_type_comment] block
+    | ('async' | 'አሲንክ')? ('def' | 'ተግባር') NAME [type_params] &&'(' [params] ')' ['->' expression] &&':' [func_type_comment] block
 invalid_class_def_raw:
-    | 'class' NAME [type_params] ['(' [arguments] ')'] NEWLINE { RAISE_SYNTAX_ERROR("expected ':'") }
-    | a='class' NAME [type_params] ['(' [arguments] ')'] ':' NEWLINE !INDENT {
+    | ('class' | 'ክፍል') NAME [type_params] ['(' [arguments] ')'] NEWLINE { RAISE_SYNTAX_ERROR("expected ':'") }
+    | a=('class' | 'ክፍል') NAME [type_params] ['(' [arguments] ')'] ':' NEWLINE !INDENT {
         RAISE_INDENTATION_ERROR("expected an indented block after class definition on line %d", a->lineno) }
 
 invalid_double_starred_kvpairs:
@@ -1547,9 +1544,9 @@ invalid_tstring_conversion_character:
     | '!' !NAME { RAISE_SYNTAX_ERROR_ON_NEXT_TOKEN("t-string: invalid conversion character") }
 
 invalid_arithmetic:
-    | sum ('+'|'-'|'*'|'/'|'%'|'//'|'@') a='not' b=inversion { RAISE_SYNTAX_ERROR_KNOWN_RANGE(a, b, "'not' after an operator must be parenthesized") }
+    | sum ('+'|'-'|'*'|'/'|'%'|'//'|'@') a=('not' | 'አይደለም') b=inversion { RAISE_SYNTAX_ERROR_KNOWN_RANGE(a, b, "'not' after an operator must be parenthesized") }
 invalid_factor:
-    | ('+' | '-' | '~') a='not' b=factor { RAISE_SYNTAX_ERROR_KNOWN_RANGE(a, b, "'not' after an operator must be parenthesized") }
+    | ('+' | '-' | '~') a=('not' | 'አይደለም') b=factor { RAISE_SYNTAX_ERROR_KNOWN_RANGE(a, b, "'not' after an operator must be parenthesized") }
 
 invalid_type_params:
     | '[' token=']' {

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -3307,6 +3307,7 @@ static PyMethodDef builtin_methods[] = {
     BUILTIN_ORD_METHODDEF
     BUILTIN_POW_METHODDEF
     BUILTIN_PRINT_METHODDEF
+    {"አትም", _PyCFunction_CAST(builtin_print_impl), METH_FASTCALL | METH_KEYWORDS, builtin_print__doc__},
     BUILTIN_REPR_METHODDEF
     BUILTIN_ROUND_METHODDEF
     BUILTIN_SETATTR_METHODDEF

--- a/README.md
+++ b/README.md
@@ -1,0 +1,111 @@
+# CPython with Amharic Language Support
+
+## Introduction
+
+This modified version of CPython allows developers to write Python code using Amharic keywords and selected Amharic function names directly. This feature aims to make Python programming more accessible and intuitive for Amharic-speaking developers.
+
+The modifications involve changes to the CPython interpreter's lexer (keyword definitions in `pegen/c_generator.py`), parser (grammar rules in `Grammar/python.gram`), and built-in function definitions (`Python/bltinmodule.c`).
+
+## Features
+
+### Amharic Keywords
+
+Standard Python keywords can be replaced with their Amharic equivalents. Below is a list of supported Amharic keywords and their corresponding English Python keywords:
+
+| Amharic Keyword | English Keyword |
+|-----------------|-----------------|
+| ሐሰት            | False           |
+| ምንም            | None            |
+| እውነት            | True            |
+| እና             | and             |
+| እንደ            | as              |
+| አረጋግጥ          | assert          |
+| አሲንክ           | async           |
+| ተጠባበቅ          | await           |
+| አቋርጥ           | break           |
+| ክፍል            | class           |
+| ቀጥል            | continue        |
+| ተግባር           | def             |
+| ሰርዝ            | del             |
+| ካልሆነ-ከሆነ      | elif            |
+| አለበለዚያ        | else            |
+| በስተቀር          | except          |
+| በመጨረሻ          | finally         |
+| ለእያንዳንዱ       | for             |
+| ከ              | from            |
+| አለምአቀፍ         | global          |
+| ከሆነ            | if              |
+| አስገባ           | import          |
+| ውስጥ            | in              |
+| ነው             | is              |
+| ላምዳ            | lambda          |
+| ከባቢያዊ-ያልሆነ   | nonlocal        |
+| አይደለም          | not             |
+| ወይም            | or              |
+| እለፍ            | pass            |
+| አስነሳ           | raise           |
+| መልስ            | return          |
+| ሞክር            | try             |
+| እስከ            | while           |
+| አብሮ            | with            |
+| አመንጭ           | yield           |
+
+### Amharic Function Aliases
+
+Selected built-in functions have Amharic aliases. Currently, this includes:
+
+*   **`print`**: `አትም`
+
+## How to Build
+
+To build this modified CPython from source, follow these steps:
+
+1.  **Install Build Dependencies**: Ensure your system has all the necessary dependencies for building CPython. This typically includes a C compiler (like GCC or Clang), make, and other development libraries. Refer to the official CPython [Developer's Guide](https://devguide.python.org/getting-started/setup-building/) for detailed prerequisites for your operating system.
+
+2.  **Regenerate Parser and Other Generated Files**: Due to the changes in the grammar and keyword definitions, you need to regenerate the parser and other auto-generated files. Run the following command from the root of the CPython repository:
+    ```bash
+    make regen-all
+    ```
+
+3.  **Compile CPython**: After regenerating the necessary files, compile CPython using:
+    ```bash
+    make
+    ```
+    For a faster build, you can use parallel compilation by specifying the number of jobs (e.g., `make -j8` if you have 8 CPU cores).
+
+## Example Usage
+
+Here's a simple Python code snippet demonstrating the use of Amharic keywords and the `አትም` print alias:
+
+```python
+# Example Amharic-Python
+
+ተግባር አስላ(ሀ, ለ):
+  ከሆነ ሀ > ለ:
+    መልስ ሀ - ለ
+  አለበለዚያ:
+    መልስ ለ - ሀ
+
+አትም(አስላ(5, 10)) # Output: 5
+
+አትም("ሰላም፣ ዓለም!") # Output: ሰላም፣ ዓለም!
+
+ለእያንዳንዱ ንጥል ውስጥ [1, 2, 3]:
+    ከሆነ ንጥል == 2:
+        አትም("2 ተገኝቷል!")
+        ቀጥል
+    አትም(ንጥል)
+
+ከሆነ እውነት እና አይደለም ሐሰት:
+    አትም("ሎጂክ ይሰራል!")
+```
+
+## Note on Build Errors
+
+If you encounter build errors after modifying the grammar or other core files:
+*   Ensure that `make regen-all` was run successfully. Missing this step is a common source of issues.
+*   Double-check that all build dependencies for CPython are correctly installed on your system.
+*   Clean your build directory (`make clean` or `git clean -fdx`) and try the build process again.
+*   For specific errors, consult the error messages provided by the compiler, as they often point to the exact location and nature of the problem.
+
+This project aims to be a proof-of-concept and a starting point for broader Amharic language integration in Python.

--- a/Tools/peg_generator/pegen/c_generator.py
+++ b/Tools/peg_generator/pegen/c_generator.py
@@ -488,21 +488,89 @@ class CParserGenerator(ParserGenerator, GrammarVisitor):
         return groups
 
     def _setup_keywords(self) -> None:
-        n_keyword_lists = (
-            len(max(self.keywords.keys(), key=len)) + 1 if len(self.keywords) > 0 else 0
-        )
+        AMHARIC_TO_ENGLISH_KEYWORDS = {
+            "ሐሰት": "False",
+            "ምንም": "None",
+            "እውነት": "True",
+            "እና": "and",
+            "እንደ": "as",
+            "አረጋግጥ": "assert",
+            "አሲንክ": "async",
+            "ተጠባበቅ": "await",
+            "አቋርጥ": "break",
+            "ክፍል": "class",
+            "ቀጥል": "continue",
+            "ተግባር": "def",
+            "ሰርዝ": "del",
+            "ካልሆነ-ከሆነ": "elif",
+            "አለበለዚያ": "else",
+            "በስተቀር": "except",
+            "በመጨረሻ": "finally",
+            "ለእያንዳንዱ": "for",
+            "ከ": "from",
+            "አለምአቀፍ": "global",
+            "ከሆነ": "if",
+            "አስገባ": "import",
+            "ውስጥ": "in",
+            "ነው": "is",
+            "ላምዳ": "lambda",
+            "ከባቢያዊ-ያልሆነ": "nonlocal",
+            "አይደለም": "not",
+            "ወይም": "or",
+            "እለፍ": "pass",
+            "አስነሳ": "raise",
+            "መልስ": "return",
+            "ሞክር": "try",
+            "እስከ": "while",
+            "አብሮ": "with",
+            "አመንጭ": "yield",
+        }
+
+        all_keywords_with_types: Dict[str, int] = {}
+        # Populate with original English keywords
+        for keyword_str, keyword_type in self.keywords.items():
+            all_keywords_with_types[keyword_str] = keyword_type
+
+        # Add Amharic keywords, mapping them to the token types of their English counterparts
+        for amharic_keyword, english_keyword in AMHARIC_TO_ENGLISH_KEYWORDS.items():
+            if english_keyword in self.keywords:
+                token_type = self.keywords[english_keyword]
+                all_keywords_with_types[amharic_keyword] = token_type
+            # else:
+            #     # This case should ideally not happen if the mapping is correct
+            #     # and all English keywords are defined in the grammar.
+            #     # Consider logging a warning or error if necessary.
+            #     # print(f"Warning: English keyword '{english_keyword}' for Amharic '{amharic_keyword}' not found in self.keywords.")
+            #     pass
+
+        groups: Dict[int, List[Tuple[str, int]]] = {}
+        max_len_utf8 = 0
+        if not all_keywords_with_types: # Handle case with no keywords at all
+            n_keyword_lists = 0
+        else:
+            for keyword_str, keyword_type in all_keywords_with_types.items():
+                byte_length = len(keyword_str.encode('utf-8'))
+                if byte_length > max_len_utf8:
+                    max_len_utf8 = byte_length
+                if byte_length in groups:
+                    # Ensure no duplicate keyword strings are added to the same length group.
+                    # This check is simple; more robust might be needed if complex aliasing occurs.
+                    if not any(k_str == keyword_str for k_str, _ in groups[byte_length]):
+                        groups[byte_length].append((keyword_str, keyword_type))
+                else:
+                    groups[byte_length] = [(keyword_str, keyword_type)]
+            n_keyword_lists = max_len_utf8 + 1
+
         self.print(f"static const int n_keyword_lists = {n_keyword_lists};")
-        groups = self._group_keywords_by_length()
         self.print("static KeywordToken *reserved_keywords[] = {")
         with self.indent():
-            num_groups = max(groups) + 1 if groups else 1
-            for keywords_length in range(num_groups):
-                if keywords_length not in groups.keys():
+            for keywords_length_utf8 in range(n_keyword_lists):
+                if keywords_length_utf8 not in groups:
                     self.print("(KeywordToken[]) {{NULL, -1}},")
                 else:
                     self.print("(KeywordToken[]) {")
                     with self.indent():
-                        for keyword_str, keyword_type in groups[keywords_length]:
+                        for keyword_str, keyword_type in groups[keywords_length_utf8]:
                             self.print(f'{{"{keyword_str}", {keyword_type}}},')
                         self.print("{NULL, -1},")
                     self.print("},")


### PR DESCRIPTION
This commit introduces two main updates:

1.  **Amharic Print Alias (`አትም`)**:
    *   I modified the `Python/bltinmodule.c` file to include "አትም" as an Amharic alias for the built-in `print` function.
    *   This allows you to call `አትም(...)` with the same functionality as `print(...)`.

2.  **README File Creation**:
    *   I added a new `README.md` file to the repository root.
    *   This README provides an overview of the Amharic language support feature (both keywords and the print alias), lists the keyword mappings, gives build instructions (`make regen-all` and `make`), and includes an example code snippet.

These changes enhance the usability of the Amharic-enabled CPython by providing a translated print function and documenting the overall feature.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
